### PR TITLE
Prevent auto-selection of new units and add spawn cues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,9 @@ html,body{height:100%;margin:0;background:#0b0e16;color:#e6e8ef;font-family:syst
     .hpbar>span{display:block;height:100%;background:#36d399}
     #orderFlash{margin-top:6px;font-size:11px;color:#cfe8ff;opacity:0;transition:opacity .25s ease}
     #orderFlash.show{opacity:1}
+    #unitReadyNotice{margin-top:6px;font-size:11px;color:#f5d590;opacity:0;transform:translateY(4px);
+        transition:opacity .25s ease,transform .25s ease}
+    #unitReadyNotice.show{opacity:1;transform:translateY(0)}
 
     /* Minimap */
     #minimapWrap{

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <h4><span>Selected</span><span id="selCount">0</span></h4>
     <div class="grid" id="selGrid"></div>
     <div id="orderFlash">Order: Move</div>
+    <div id="unitReadyNotice"></div>
   </div>
 
   <!-- Minimap -->


### PR DESCRIPTION
## Summary
- stop player barracks from auto-adding newly trained units to the current selection
- add a brief on-map glow plus a HUD notice so fresh units are easy to spot when training completes
- track and clear the new spawn indicators when the game resets

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68d41191efd48325a326a97839a1b987